### PR TITLE
Added initial value for twitter_folder

### DIFF
--- a/tmd.py
+++ b/tmd.py
@@ -21,10 +21,11 @@ def parse_arguments():
     url_arg = False
     previews = False
     word_filter = False
+    twitter_folder = False
 
     if len(sys.argv) < 2:
         input('No arguments given\n'
-              'Press Enter to continue ')
+              'Press Enter to continue: ')
         sys.exit()
 
     for index, arg in enumerate(sys.argv):


### PR DESCRIPTION
Added an initial value of False for twitter_folder to make the -t argument optional.

Without the initial value, the program throws an exception for evaluating twitter_folder without a value at line 194 if the -t argument is not set.